### PR TITLE
feature: display object names in the hierarchy window

### DIFF
--- a/src/components/MeshController.tsx
+++ b/src/components/MeshController.tsx
@@ -1,41 +1,50 @@
-import { ReactNode, useRef, useState } from 'react';
+import { ReactNode, RefObject, useCallback, useRef, useState } from 'react';
 import { ThreeEvent } from '@react-three/fiber';
 import * as THREE from 'three';
+import { useEditorContext } from '../hooks/useEditorContext';
+import ControllerProps from '../types/ControllerProps';
+import { SceneObject } from '../types/SceneObject';
+import { useThree } from '@react-three/fiber';
 
 function GenericMesh({
-  parentCallback,
   children,
+  uuid,
   ...props
-}: {
-  parentCallback: (ref: React.RefObject<THREE.Mesh>) => void;
-  children?: ReactNode;
-}) {
+}: ControllerProps) {
   const localRef = useRef<THREE.Mesh>(null!);
-  const [hovered, setHovered] = useState(false);
-  const [clicked, setClicked] = useState(false);
+  const [hovered, hover] = useState(false);
+  const [clicked, click] = useState(false);
+  const { focus, sceneObjects, setSceneObjects } = useEditorContext();
+  const { scene } = useThree();
+  console.log(scene);
+
 
   const handleClick = (e: ThreeEvent<PointerEvent>) => {
     e.stopPropagation();
-    setClicked(!clicked);
-    if (parentCallback) {
-      parentCallback(localRef);
-    }
+    click(!clicked);
+    focus(uuid ?? "");
   };
+
 
   const handlePointerOver = (e: ThreeEvent<PointerEvent>) => {
     e.stopPropagation();
-    setHovered(true);
+    hover(true);
   };
 
   const handlePointerOut = (e: ThreeEvent<PointerEvent>) => {
     e.stopPropagation();
-    setHovered(false);
+    hover(false);
   };
+
+  const handleRef = useCallback((node: RefObject<THREE.Mesh>) => {
+    const updatedSceneObject: SceneObject = {...sceneObjects[uuid ?? ""], ref: node }
+    setSceneObjects({...sceneObjects, [uuid ?? ""]: updatedSceneObject});
+    }, []);
 
   return (
     <mesh
       {...props}
-      ref={localRef}
+      ref={handleRef}
       onClick={handleClick}
       onPointerOver={handlePointerOver}
       onPointerOut={handlePointerOut}

--- a/src/components/MeshController.tsx
+++ b/src/components/MeshController.tsx
@@ -1,30 +1,19 @@
-import { ReactNode, RefObject, useCallback, useRef, useState } from 'react';
+import { RefObject, useCallback, useState } from 'react';
 import { ThreeEvent } from '@react-three/fiber';
 import * as THREE from 'three';
 import { useEditorContext } from '../hooks/useEditorContext';
 import ControllerProps from '../types/ControllerProps';
-import { SceneObject } from '../types/SceneObject';
-import { useThree } from '@react-three/fiber';
 
-function GenericMesh({
-  children,
-  uuid,
-  ...props
-}: ControllerProps) {
-  const localRef = useRef<THREE.Mesh>(null!);
+function GenericMesh({ children, objectUuid, ...props }: ControllerProps) {
   const [hovered, hover] = useState(false);
   const [clicked, click] = useState(false);
-  const { focus, sceneObjects, setSceneObjects } = useEditorContext();
-  const { scene } = useThree();
-  console.log(scene);
-
+  const { focus, setSceneObjects } = useEditorContext();
 
   const handleClick = (e: ThreeEvent<PointerEvent>) => {
     e.stopPropagation();
     click(!clicked);
-    focus(uuid ?? "");
+    focus(objectUuid);
   };
-
 
   const handlePointerOver = (e: ThreeEvent<PointerEvent>) => {
     e.stopPropagation();
@@ -36,10 +25,18 @@ function GenericMesh({
     hover(false);
   };
 
-  const handleRef = useCallback((node: RefObject<THREE.Mesh>) => {
-    const updatedSceneObject: SceneObject = {...sceneObjects[uuid ?? ""], ref: node }
-    setSceneObjects({...sceneObjects, [uuid ?? ""]: updatedSceneObject});
-    }, []);
+  const handleRef = useCallback(
+    (node: RefObject<THREE.Mesh>) => {
+      setSceneObjects((prevObjects) => ({
+        ...prevObjects,
+        [objectUuid]: {
+          ...prevObjects[objectUuid],
+          ref: node,
+        },
+      }));
+    },
+    [objectUuid, setSceneObjects],
+  );
 
   return (
     <mesh

--- a/src/components/editor/CanvasController.tsx
+++ b/src/components/editor/CanvasController.tsx
@@ -1,47 +1,32 @@
 import { Canvas } from '@react-three/fiber';
 import { Grid, OrbitControls, TransformControls } from '@react-three/drei';
 import ToolbarComponent from './Toolbar';
-import { JSX, RefObject, useState } from 'react';
-import * as THREE from 'three';
+import { useState } from 'react';
 import OrientationCube from './OrientationCube';
 import EditingMode from '../../types/EditingMode';
+import { useEditorContext } from '../../hooks/useEditorContext';
 
-interface CanvasControllerProps {
-  objects: JSX.Element[];
-  currentRef?: RefObject<THREE.Mesh> | null;
-  setRef: (ref: RefObject<THREE.Mesh> | null) => void;
-}
-
-function CanvasController({
-  objects,
-  currentRef,
-  setRef,
-}: CanvasControllerProps) {
+function CanvasController() {
   const [mode, selectMode] = useState<EditingMode>('translate');
-
-  const unfocusObject = () => {
-    if (currentRef?.current) {
-      setRef(null);
-    }
-  };
+  const { sceneObjects, focused, focus } = useEditorContext();
 
   return (
     <div className="canvas-container">
       <ToolbarComponent editingMode={mode} selectMode={selectMode} />
       <Canvas
         className="canvas"
-        onPointerMissed={unfocusObject}
+        onPointerMissed={() => focus(null)}
         camera={{ position: [3, 2, -3] }}
       >
         <ambientLight />
         <directionalLight position={[10, 10, 10]} />
         <OrbitControls makeDefault enableDamping={false} />
-        {currentRef?.current ? (
-          <TransformControls object={currentRef} mode={mode} />
+        {focused?.current ? (
+          <TransformControls object={focused} mode={mode} />
         ) : undefined}
         <Grid sectionSize={2} infiniteGrid />
         <OrientationCube />
-        {objects}
+        {sceneObjects.map((object) => object.component)}
       </Canvas>
     </div>
   );

--- a/src/components/editor/CanvasController.tsx
+++ b/src/components/editor/CanvasController.tsx
@@ -21,12 +21,14 @@ function CanvasController() {
         <ambientLight />
         <directionalLight position={[10, 10, 10]} />
         <OrbitControls makeDefault enableDamping={false} />
-        {focused? (
+        {focused ? (
           <TransformControls object={sceneObjects[focused].ref} mode={mode} />
         ) : undefined}
         <Grid sectionSize={2} infiniteGrid />
         <OrientationCube />
-        {Object.values(sceneObjects).map((object) => object.component)}
+        {Object.entries(sceneObjects).map(([uuid, object]) => (
+          <object.component objectUuid={uuid} />
+        ))}
       </Canvas>
     </div>
   );

--- a/src/components/editor/CanvasController.tsx
+++ b/src/components/editor/CanvasController.tsx
@@ -21,12 +21,12 @@ function CanvasController() {
         <ambientLight />
         <directionalLight position={[10, 10, 10]} />
         <OrbitControls makeDefault enableDamping={false} />
-        {focused?.current ? (
-          <TransformControls object={focused} mode={mode} />
+        {focused? (
+          <TransformControls object={sceneObjects[focused].ref} mode={mode} />
         ) : undefined}
         <Grid sectionSize={2} infiniteGrid />
         <OrientationCube />
-        {sceneObjects.map((object) => object.component)}
+        {Object.values(sceneObjects).map((object) => object.component)}
       </Canvas>
     </div>
   );

--- a/src/components/editor/HierarchyWindow.tsx
+++ b/src/components/editor/HierarchyWindow.tsx
@@ -1,21 +1,34 @@
+import React, { RefObject, useEffect, useRef } from 'react';
 import { useEditorContext } from '../../hooks/useEditorContext';
-import SceneObject from '../../types/SceneObject';
 
 function HierarchyWindow() {
-  const { sceneObjects, focused } = useEditorContext();
+  const { sceneObjects, focused, focus } = useEditorContext();
+  const parentRef = useRef<HTMLDivElement>(null);
 
-  const handleOnClick = (object: SceneObject) => {
-    console.log(focused);
-    console.log(object.component);
-  }
+  // TODO: make it more generic and extract it to a hook
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      const isInsideParent = parentRef.current?.contains(event.target as Node);
+      // TODO: this is kinda stupid, but `eventListener` gets called before `onClick`
+      // so on a valid object click it will override null
+      if (isInsideParent) focus(null);
+    }
 
+    document.addEventListener("mousedown", handleClick);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+    };
+  }, [])
+  
   return (
-    <div className="hierarchy-window">
+    <div className="hierarchy-window" ref={parentRef}>
       <h3>Hierarchy</h3>
-      {sceneObjects.map((object) => (
+      {Object.entries(sceneObjects).map(([uuid, object]) => (
         <div
+          key={uuid}
           className="hierarchy-window__item"
-          onClick={() => handleOnClick(object)}
+          onClick={() => focus(uuid)}
+          style={{background: focused == uuid ?  "#555" : ""}}
         >
           {object.geometryType}
         </div>

--- a/src/components/editor/HierarchyWindow.tsx
+++ b/src/components/editor/HierarchyWindow.tsx
@@ -1,17 +1,25 @@
-import { JSX } from 'react';
-interface HierarchyWindowProps {
-  objects: JSX.Element[];
-}
+import { useEditorContext } from '../../hooks/useEditorContext';
+import SceneObject from '../../types/SceneObject';
 
-function HierarchyWindow({ objects }: HierarchyWindowProps) {
+function HierarchyWindow() {
+  const { sceneObjects, focused } = useEditorContext();
+
+  const handleOnClick = (object: SceneObject) => {
+    console.log(focused);
+    console.log(object.component);
+  }
+
   return (
     <div className="hierarchy-window">
       <h3>Hierarchy</h3>
-      <div>
-        {objects.map(() => (
-          <div>text</div>
-        ))}
-      </div>
+      {sceneObjects.map((object) => (
+        <div
+          className="hierarchy-window__item"
+          onClick={() => handleOnClick(object)}
+        >
+          {object.geometryType}
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/components/editor/HierarchyWindow.tsx
+++ b/src/components/editor/HierarchyWindow.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useEditorContext } from '../../hooks/useEditorContext';
 
 function HierarchyWindow() {
@@ -12,14 +12,14 @@ function HierarchyWindow() {
       // TODO: this is kinda stupid, but `eventListener` gets called before `onClick`
       // so on a valid object click it will override null
       if (isInsideParent) focus(null);
-    }
-
-    document.addEventListener("mousedown", handleClick);
-    return () => {
-      document.removeEventListener("mousedown", handleClick);
     };
-  }, [])
-  
+
+    document.addEventListener('mousedown', handleClick);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+    };
+  }, [focus]);
+
   return (
     <div className="hierarchy-window" ref={parentRef}>
       <h3>Hierarchy</h3>
@@ -28,9 +28,9 @@ function HierarchyWindow() {
           key={uuid}
           className="hierarchy-window__item"
           onClick={() => focus(uuid)}
-          style={{background: focused == uuid ?  "#555" : ""}}
+          style={{ background: focused == uuid ? '#555' : '' }}
         >
-          {object.geometryType}
+          {object.name}
         </div>
       ))}
     </div>

--- a/src/components/editor/Navigation.tsx
+++ b/src/components/editor/Navigation.tsx
@@ -1,21 +1,19 @@
-import { JSX, RefObject } from 'react';
 import { MenuItem } from '@mui/material';
 import Objects from '../../data/ObjectNames';
 import NavigationItem from './NavigationItem';
-import ControllerProps from '../../types/ControllerProps';
-import * as THREE from 'three';
+import SceneObject from '../../types/SceneObject';
+import { useEditorContext } from '../../hooks/useEditorContext';
 
-interface NavigationProps {
-  addMesh: (mesh: JSX.Element) => void;
-  setRef: (ref: RefObject<THREE.Mesh>) => void;
-}
+function Navigation() {
+  const { setSceneObjects, focus } = useEditorContext();
 
-function Navigation({ addMesh, setRef }: NavigationProps) {
-  const handleAdd = (
-    _: React.MouseEvent<HTMLElement>,
-    Component: React.ComponentType<ControllerProps>,
-  ) => {
-    addMesh(<Component position={[0, 0, 0]} parentCallback={setRef} />);
+  const handleAdd = (object: typeof Objects[0]) => {
+    const newObject: SceneObject = {
+      id: crypto.randomUUID(), 
+      geometryType: object.name,
+      component: <object.component parentCallback={focus} />
+    };
+    setSceneObjects((old) => [...old, newObject])
   };
 
   return (
@@ -24,7 +22,7 @@ function Navigation({ addMesh, setRef }: NavigationProps) {
         {Objects.map((object) => (
           <MenuItem
             key={object.id}
-            onClick={(e) => handleAdd(e, object.component)}
+            onClick={() => handleAdd(object)}
           >
             {object.name}
           </MenuItem>

--- a/src/components/editor/Navigation.tsx
+++ b/src/components/editor/Navigation.tsx
@@ -1,19 +1,19 @@
 import { MenuItem } from '@mui/material';
 import Objects from '../../data/ObjectNames';
 import NavigationItem from './NavigationItem';
-import SceneObject from '../../types/SceneObject';
+import { SceneObject } from '../../types/SceneObject';
 import { useEditorContext } from '../../hooks/useEditorContext';
 
 function Navigation() {
-  const { setSceneObjects, focus } = useEditorContext();
+  const { sceneObjects, setSceneObjects } = useEditorContext();
 
   const handleAdd = (object: typeof Objects[0]) => {
+    const uuid = crypto.randomUUID();
     const newObject: SceneObject = {
-      id: crypto.randomUUID(), 
       geometryType: object.name,
-      component: <object.component parentCallback={focus} />
+      component: <object.component uuid={uuid} />
     };
-    setSceneObjects((old) => [...old, newObject])
+    setSceneObjects({...sceneObjects, [uuid]: newObject})
   };
 
   return (

--- a/src/components/editor/Navigation.tsx
+++ b/src/components/editor/Navigation.tsx
@@ -7,23 +7,16 @@ import { useEditorContext } from '../../hooks/useEditorContext';
 function Navigation() {
   const { sceneObjects, setSceneObjects } = useEditorContext();
 
-  const handleAdd = (object: typeof Objects[0]) => {
+  const handleAdd = (object: SceneObject) => {
     const uuid = crypto.randomUUID();
-    const newObject: SceneObject = {
-      geometryType: object.name,
-      component: <object.component uuid={uuid} />
-    };
-    setSceneObjects({...sceneObjects, [uuid]: newObject})
+    setSceneObjects({ ...sceneObjects, [uuid]: object });
   };
 
   return (
     <div className="tool-bar">
       <NavigationItem label="Shapes">
         {Objects.map((object) => (
-          <MenuItem
-            key={object.id}
-            onClick={() => handleAdd(object)}
-          >
+          <MenuItem key={object.id} onClick={() => handleAdd(object)}>
             {object.name}
           </MenuItem>
         ))}

--- a/src/components/editor/objects/BoxController.tsx
+++ b/src/components/editor/objects/BoxController.tsx
@@ -1,9 +1,9 @@
 import GenericMesh from '../../MeshController';
 import ControllerProps from '../../../types/ControllerProps';
 
-function BoxController({ children, parentCallback }: ControllerProps) {
+function BoxController({ children, ...props }: ControllerProps) {
   return (
-    <GenericMesh parentCallback={parentCallback}>
+    <GenericMesh {...props}>
       <boxGeometry args={[1, 1, 1]} />
       {children}
     </GenericMesh>

--- a/src/components/editor/objects/CapsuleController.tsx
+++ b/src/components/editor/objects/CapsuleController.tsx
@@ -1,9 +1,9 @@
 import ControllerProps from '../../../types/ControllerProps';
 import GenericMesh from '../../MeshController';
 
-function CapsuleController({ children, parentCallback }: ControllerProps) {
+function CapsuleController({ children, ...props }: ControllerProps) {
   return (
-    <GenericMesh parentCallback={parentCallback}>
+    <GenericMesh {...props}>
       <capsuleGeometry args={[1, 2, 8, 16]} />
       {children}
     </GenericMesh>

--- a/src/components/editor/objects/CircleController.tsx
+++ b/src/components/editor/objects/CircleController.tsx
@@ -1,9 +1,9 @@
 import GenericMesh from '../../MeshController';
 import ControllerProps from '../../../types/ControllerProps';
 
-function CircleController({ children, parentCallback }: ControllerProps) {
+function CircleController({ children, ...props }: ControllerProps) {
   return (
-    <GenericMesh parentCallback={parentCallback}>
+    <GenericMesh {...props}>
       <circleGeometry args={[1.5, 32]} />
       {children}
     </GenericMesh>

--- a/src/components/editor/objects/ConeController.tsx
+++ b/src/components/editor/objects/ConeController.tsx
@@ -1,9 +1,9 @@
 import GenericMesh from '../../MeshController';
 import ControllerProps from '../../../types/ControllerProps';
 
-function ConeController({ children, parentCallback }: ControllerProps) {
+function ConeController({ children, ...props }: ControllerProps) {
   return (
-    <GenericMesh parentCallback={parentCallback}>
+    <GenericMesh {...props}>
       <coneGeometry args={[1, 2, 32]} />
       {children}
     </GenericMesh>

--- a/src/components/editor/objects/CylinderController.tsx
+++ b/src/components/editor/objects/CylinderController.tsx
@@ -1,9 +1,9 @@
 import GenericMesh from '../../MeshController';
 import ControllerProps from '../../../types/ControllerProps';
 
-function CylinderController({ children, parentCallback }: ControllerProps) {
+function CylinderController({ children, ...props }: ControllerProps) {
   return (
-    <GenericMesh parentCallback={parentCallback}>
+    <GenericMesh {...props}>
       <cylinderGeometry args={[1, 1, 2, 32]} />
       {children}
     </GenericMesh>

--- a/src/components/editor/objects/DodecahedronController.tsx
+++ b/src/components/editor/objects/DodecahedronController.tsx
@@ -1,9 +1,9 @@
 import GenericMesh from '../../MeshController';
 import ControllerProps from '../../../types/ControllerProps';
 
-function DodecahedronController({ children, parentCallback }: ControllerProps) {
+function DodecahedronController({ children, ...props }: ControllerProps) {
   return (
-    <GenericMesh parentCallback={parentCallback}>
+    <GenericMesh {...props}>
       <dodecahedronGeometry args={[1, 0]} />
       {children}
     </GenericMesh>

--- a/src/components/editor/objects/ExtrudeController.tsx
+++ b/src/components/editor/objects/ExtrudeController.tsx
@@ -2,7 +2,7 @@ import GenericMesh from '../../MeshController';
 import * as THREE from 'three';
 import ControllerProps from '../../../types/ControllerProps';
 
-function ExtrudeController({ children, parentCallback }: ControllerProps) {
+function ExtrudeController({ children, ...props }: ControllerProps) {
   const shape = new THREE.Shape();
   shape.moveTo(0, 0);
   shape.lineTo(1, 0);
@@ -20,7 +20,7 @@ function ExtrudeController({ children, parentCallback }: ControllerProps) {
   };
 
   return (
-    <GenericMesh parentCallback={parentCallback}>
+    <GenericMesh {...props}>
       <extrudeGeometry args={[shape, extrudeSettings]} />
       {children}
     </GenericMesh>

--- a/src/components/editor/objects/LatheController.tsx
+++ b/src/components/editor/objects/LatheController.tsx
@@ -2,14 +2,14 @@ import GenericMesh from '../../MeshController';
 import * as THREE from 'three';
 import ControllerProps from '../../../types/ControllerProps';
 
-function LatheController({ children, parentCallback }: ControllerProps) {
+function LatheController({ children, ...props }: ControllerProps) {
   const points = [];
   for (let i = 0; i < 10; i++) {
     points.push(new THREE.Vector2(Math.sin(i * 0.2) * 1.5 + 1, (i - 5) * 0.4));
   }
 
   return (
-    <GenericMesh parentCallback={parentCallback}>
+    <GenericMesh {...props}>
       <latheGeometry args={[points, 32]} />
       {children}
     </GenericMesh>

--- a/src/components/editor/objects/OctahedronController.tsx
+++ b/src/components/editor/objects/OctahedronController.tsx
@@ -1,9 +1,9 @@
 import GenericMesh from '../../MeshController';
 import ControllerProps from '../../../types/ControllerProps';
 
-function OctahedronController({ children, parentCallback }: ControllerProps) {
+function OctahedronController({ children, ...props }: ControllerProps) {
   return (
-    <GenericMesh parentCallback={parentCallback}>
+    <GenericMesh {...props}>
       <octahedronGeometry args={[1, 0]} />
       {children}
     </GenericMesh>

--- a/src/components/editor/objects/PlaneController.tsx
+++ b/src/components/editor/objects/PlaneController.tsx
@@ -1,9 +1,9 @@
 import GenericMesh from '../../MeshController';
 import ControllerProps from '../../../types/ControllerProps';
 
-function PlaneController({ children, parentCallback }: ControllerProps) {
+function PlaneController({ children, ...props }: ControllerProps) {
   return (
-    <GenericMesh parentCallback={parentCallback}>
+    <GenericMesh {...props}>
       <planeGeometry args={[3, 3, 32, 32]} />
       {children}
     </GenericMesh>

--- a/src/components/editor/objects/SphereController.tsx
+++ b/src/components/editor/objects/SphereController.tsx
@@ -1,9 +1,9 @@
 import GenericMesh from '../../MeshController';
 import ControllerProps from '../../../types/ControllerProps';
 
-function SphereController({ children, parentCallback }: ControllerProps) {
+function SphereController({ children, ...props }: ControllerProps) {
   return (
-    <GenericMesh parentCallback={parentCallback}>
+    <GenericMesh {...props}>
       <sphereGeometry args={[1, 32, 32]} />
       {children}
     </GenericMesh>

--- a/src/components/editor/objects/TetrahedronController.tsx
+++ b/src/components/editor/objects/TetrahedronController.tsx
@@ -1,9 +1,9 @@
 import GenericMesh from '../../MeshController';
 import ControllerProps from '../../../types/ControllerProps';
 
-function TetrahedronController({ children, parentCallback }: ControllerProps) {
+function TetrahedronController({ children, ...props }: ControllerProps) {
   return (
-    <GenericMesh parentCallback={parentCallback}>
+    <GenericMesh {...props}>
       <tetrahedronGeometry args={[1, 0]} />
       {children}
     </GenericMesh>

--- a/src/components/editor/objects/TorusController.tsx
+++ b/src/components/editor/objects/TorusController.tsx
@@ -1,8 +1,9 @@
 import GenericMesh from '../../MeshController';
 import ControllerProps from '../../../types/ControllerProps';
-function TorusController({ children, parentCallback }: ControllerProps) {
+
+function TorusController({ children, ...props }: ControllerProps) {
   return (
-    <GenericMesh parentCallback={parentCallback}>
+    <GenericMesh {...props}>
       <torusGeometry args={[0.4, 0.1, 16, 100]} />
       {children}
     </GenericMesh>

--- a/src/css/2-components/hierarchy-window.scss
+++ b/src/css/2-components/hierarchy-window.scss
@@ -1,7 +1,9 @@
 .hierarchy-window {
-    padding: 10px;
-}
-
-.hierarchy-window__item {
-    background: white;
+    user-select: none;
+    h3 {
+        padding: 0 10px;
+    }
+    &__item {
+        padding: 0 10px;
+    }
 }

--- a/src/css/2-components/hierarchy-window.scss
+++ b/src/css/2-components/hierarchy-window.scss
@@ -1,0 +1,7 @@
+.hierarchy-window {
+    padding: 10px;
+}
+
+.hierarchy-window__item {
+    background: white;
+}

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -9,3 +9,4 @@
 @import '1-pages/login';
 
 @import '2-components/navbar';
+@import '2-components/hierarchy-window';

--- a/src/data/EditorContext.ts
+++ b/src/data/EditorContext.ts
@@ -1,0 +1,13 @@
+import { createContext, Dispatch, SetStateAction } from 'react';
+import { SceneObjects } from '../types/SceneObject';
+
+export interface EditorContextValues {
+  sceneObjects: SceneObjects;
+  setSceneObjects: Dispatch<SetStateAction<SceneObjects>>;
+  focused: string | null;
+  focus: Dispatch<SetStateAction<string | null>>;
+}
+
+export const EditorContext = createContext<EditorContextValues | undefined>(
+  undefined,
+);

--- a/src/data/ObjectNames.tsx
+++ b/src/data/ObjectNames.tsx
@@ -11,8 +11,9 @@ import OctahedronController from '../components/editor/objects/OctahedronControl
 import PlaneController from '../components/editor/objects/PlaneController';
 import SphereController from '../components/editor/objects/SphereController';
 import TetrahedronController from '../components/editor/objects/TetrahedronController';
+import { SceneObject } from '../types/SceneObject';
 
-const Objects = [
+const Objects: SceneObject[] = [
   {
     id: 1,
     name: 'Torus',
@@ -38,7 +39,7 @@ const Objects = [
   },
 
   {
-    id: 4,
+    id: 5,
     name: 'Cone',
     component: ConeController,
   },

--- a/src/hooks/useEditorContext.ts
+++ b/src/hooks/useEditorContext.ts
@@ -1,10 +1,12 @@
-import { useContext } from "react";
-import { EditorContext } from "../pages/Editor";
+import { useContext } from 'react';
+import { EditorContext } from '../data/EditorContext';
 
 export function useEditorContext() {
   const context = useContext(EditorContext);
   if (!context) {
-    throw new Error('useEditorContext must be used within EditorContext.Proivder');
+    throw new Error(
+      'useEditorContext must be used within EditorContext.Proivder',
+    );
   }
 
   return context;

--- a/src/hooks/useEditorContext.ts
+++ b/src/hooks/useEditorContext.ts
@@ -1,0 +1,11 @@
+import { useContext } from "react";
+import { EditorContext } from "../pages/Editor";
+
+export function useEditorContext() {
+  const context = useContext(EditorContext);
+  if (!context) {
+    throw new Error('useEditorContext must be used within EditorContext.Proivder');
+  }
+
+  return context;
+}

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -6,20 +6,22 @@ import ProjectWindow from '../components/editor/ProjectWindow';
 import InspectorWindow from '../components/editor/InspectorWindow';
 import Navigation from '../components/editor/Navigation';
 import * as THREE from 'three';
-import SceneObject from '../types/SceneObject';
+import { SceneObjects } from '../types/SceneObject';
 
 interface EditorContextValues {
-  sceneObjects: SceneObject[];
-  setSceneObjects: Dispatch<SetStateAction<SceneObject[]>>;
-  focused: RefObject<THREE.Mesh> | null;
-  focus: Dispatch<SetStateAction<RefObject<THREE.Mesh> | null>>;
+  sceneObjects: SceneObjects;
+  setSceneObjects: Dispatch<SetStateAction<SceneObjects>>;
+  focused: string | null;
+  focus: Dispatch<SetStateAction<string | null>>;
 }
 
 export const EditorContext = createContext<EditorContextValues | undefined>(undefined);
 
 function Editor() {
-  const [sceneObjects, setSceneObjects] = useState<SceneObject[]>([]);
-  const [focused, focus] = useState<RefObject<THREE.Mesh> | null>(null);
+  const [sceneObjects, setSceneObjects] = useState<SceneObjects>({});
+  const [focused, focus] = useState<string | null>(null);
+
+  console.log(sceneObjects);
 
   const contextValue: EditorContextValues = {
     sceneObjects,

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -1,4 +1,4 @@
-import { JSX, useState, RefObject } from 'react';
+import { useState, RefObject, createContext, Dispatch, SetStateAction } from 'react';
 import Split from 'react-split';
 import CanvasController from '../components/editor/CanvasController';
 import HierarchyWindow from '../components/editor/HierarchyWindow';
@@ -6,45 +6,56 @@ import ProjectWindow from '../components/editor/ProjectWindow';
 import InspectorWindow from '../components/editor/InspectorWindow';
 import Navigation from '../components/editor/Navigation';
 import * as THREE from 'three';
+import SceneObject from '../types/SceneObject';
+
+interface EditorContextValues {
+  sceneObjects: SceneObject[];
+  setSceneObjects: Dispatch<SetStateAction<SceneObject[]>>;
+  focused: RefObject<THREE.Mesh> | null;
+  focus: Dispatch<SetStateAction<RefObject<THREE.Mesh> | null>>;
+}
+
+export const EditorContext = createContext<EditorContextValues | undefined>(undefined);
 
 function Editor() {
-  const [objects, setObjects] = useState<JSX.Element[]>([]);
-  const [ref, setRef] = useState<RefObject<THREE.Mesh> | null>();
+  const [sceneObjects, setSceneObjects] = useState<SceneObject[]>([]);
+  const [focused, focus] = useState<RefObject<THREE.Mesh> | null>(null);
 
-  const pushMesh = (mesh: JSX.Element) => {
-    setObjects((prev) => [...prev, mesh]);
+  const contextValue: EditorContextValues = {
+    sceneObjects,
+    setSceneObjects,
+    focused,
+    focus,
   };
 
   return (
-    <div className="editor-hld">
-      <Navigation addMesh={pushMesh} setRef={setRef} />
-      <div className="editor-section">
-        <Split className="editor" direction="vertical" minSize={150}>
-          <Split
-            direction="horizontal"
-            sizes={[30, 70]}
-            minSize={[200, 400]}
-            className="editor-split"
-          >
-            <HierarchyWindow objects={objects} />
+    <EditorContext.Provider value={contextValue}>
+      <div className="editor-hld">
+        <Navigation />
+        <div className="editor-section">
+          <Split className="editor" direction="vertical" minSize={150}>
             <Split
               direction="horizontal"
-              sizes={[70, 30]}
-              minSize={[400, 250]}
+              sizes={[30, 70]}
+              minSize={[200, 400]}
               className="editor-split"
             >
-              <CanvasController
-                objects={objects}
-                currentRef={ref}
-                setRef={setRef}
-              />
-              <InspectorWindow />
+              <HierarchyWindow />
+              <Split
+                direction="horizontal"
+                sizes={[70, 30]}
+                minSize={[400, 250]}
+                className="editor-split"
+              >
+                <CanvasController />
+                <InspectorWindow />
+              </Split>
             </Split>
+            <ProjectWindow />
           </Split>
-          <ProjectWindow />
-        </Split>
+        </div>
       </div>
-    </div>
+    </EditorContext.Provider>
   );
 }
 

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -1,27 +1,16 @@
-import { useState, RefObject, createContext, Dispatch, SetStateAction } from 'react';
+import { useState } from 'react';
 import Split from 'react-split';
 import CanvasController from '../components/editor/CanvasController';
 import HierarchyWindow from '../components/editor/HierarchyWindow';
 import ProjectWindow from '../components/editor/ProjectWindow';
 import InspectorWindow from '../components/editor/InspectorWindow';
 import Navigation from '../components/editor/Navigation';
-import * as THREE from 'three';
 import { SceneObjects } from '../types/SceneObject';
-
-interface EditorContextValues {
-  sceneObjects: SceneObjects;
-  setSceneObjects: Dispatch<SetStateAction<SceneObjects>>;
-  focused: string | null;
-  focus: Dispatch<SetStateAction<string | null>>;
-}
-
-export const EditorContext = createContext<EditorContextValues | undefined>(undefined);
+import { EditorContextValues, EditorContext } from '../data/EditorContext';
 
 function Editor() {
   const [sceneObjects, setSceneObjects] = useState<SceneObjects>({});
   const [focused, focus] = useState<string | null>(null);
-
-  console.log(sceneObjects);
 
   const contextValue: EditorContextValues = {
     sceneObjects,

--- a/src/types/ControllerProps.tsx
+++ b/src/types/ControllerProps.tsx
@@ -1,8 +1,8 @@
-import { RefObject, ReactNode } from 'react';
-import * as THREE from 'three';
+import { ReactNode } from 'react';
 
 interface ControllerProps extends React.ComponentProps<'mesh'> {
   children?: ReactNode;
+  objectUuid: string;
 }
 
 export default ControllerProps;

--- a/src/types/ControllerProps.tsx
+++ b/src/types/ControllerProps.tsx
@@ -2,7 +2,6 @@ import { RefObject, ReactNode } from 'react';
 import * as THREE from 'three';
 
 interface ControllerProps extends React.ComponentProps<'mesh'> {
-  parentCallback: (ref: RefObject<THREE.Mesh>) => void;
   children?: ReactNode;
 }
 

--- a/src/types/SceneObject.ts
+++ b/src/types/SceneObject.ts
@@ -1,10 +1,12 @@
-import React, { JSX, ReactElement } from "react";
-import ControllerProps from "./ControllerProps";
+import { ReactElement, RefObject } from "react";
+import * as THREE from 'three';
 
-interface SceneObject {
-  id: string;
+export interface SceneObject {
   geometryType?: string;
+  ref?: RefObject<THREE.Mesh>;
   component: ReactElement<any, any>
 }
 
-export default SceneObject;
+export interface SceneObjects {
+  [uuid: string]: SceneObject
+}

--- a/src/types/SceneObject.ts
+++ b/src/types/SceneObject.ts
@@ -1,12 +1,14 @@
-import { ReactElement, RefObject } from "react";
+import { JSX, RefObject } from 'react';
 import * as THREE from 'three';
+import ControllerProps from './ControllerProps';
 
 export interface SceneObject {
-  geometryType?: string;
+  id: number;
+  name: string;
   ref?: RefObject<THREE.Mesh>;
-  component: ReactElement<any, any>
+  component: ({ children, ...props }: ControllerProps) => JSX.Element;
 }
 
 export interface SceneObjects {
-  [uuid: string]: SceneObject
+  [uuid: string]: SceneObject;
 }

--- a/src/types/SceneObject.ts
+++ b/src/types/SceneObject.ts
@@ -1,0 +1,10 @@
+import React, { JSX, ReactElement } from "react";
+import ControllerProps from "./ControllerProps";
+
+interface SceneObject {
+  id: string;
+  geometryType?: string;
+  component: ReactElement<any, any>
+}
+
+export default SceneObject;


### PR DESCRIPTION
closes #57 #54 

sorry troche duzo zmian tu zrobilem xd
1. nowy hook: `useEditorContext` zwraca `sceneObjects`, `setSceneObjects`, `focused` i `focus`. `sceneObjects` to obiekty ktore sa na scenie, a `focused` daje dostep do aktualnie wybranego obiektu
2. nowa struktura obiektow na scenie. wczesniej to bylo `JSX.Element[]`. aktualny format to `{ uuid: { id, nazwa, referencja, JSX.Element } }`
3. `HierarchyWindow` wyswietla nazwy obiektow na scenie i pozwala na nie kliknac zeby je zfocusowac

![image](https://github.com/user-attachments/assets/c07392a3-641f-4851-a54b-7c100b51726e)